### PR TITLE
Small changes skipping over failures

### DIFF
--- a/lib/NetworkInterface.js
+++ b/lib/NetworkInterface.js
@@ -195,7 +195,11 @@ NetworkInterface.prototype._bindSocket = function () {
       [].concat(_toConsumableArray(new Set(addresses))).filter(function (add) {
         return add.family === 'IPv4';
       }).forEach(function (add) {
-        return socket.addMembership(MDNS_ADDRESS.IPv4, add.address);
+        try {
+          return socket.addMembership(MDNS_ADDRESS.IPv4, add.address);
+	} catch (e) {
+          console.log('OUCH! - could not add membership to interface ' + add.address, e);
+	}
       });
 
       _this2._sockets.push(socket);

--- a/lib/Probe.js
+++ b/lib/Probe.js
@@ -336,6 +336,11 @@ Probe.prototype._recordsHaveConflict = function (records, incomingRecords) {
   var hasConflict = false;
   var pairs = [];
 
+  if ( ! incomingRegords ) {
+      debug('incoming records not defined yet');
+      return;
+  }
+
   for (var i = 0; i < Math.max(records.length, incomingRecords.length); i++) {
     pairs.push([records[i], incomingRecords[i]]);
   }


### PR DESCRIPTION
We have a network setup with multiple interfaces (bridges, mesh nodes etc) that triggered two exceptions. It seems this has been caused by an aliased interface - ifconfig shows it as

```
~# ifconfig
bat0      Link encap:Ethernet  HWaddr EA:D0:73:CD:38:E9  
          inet addr:192.168.17.1  Bcast:192.168.17.255  Mask:255.255.255.0
          inet6 addr: fe80::e8d0:73ff:fecd:38e9%lo/64 Scope:Link
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:61251 errors:0 dropped:0 overruns:0 frame:0
          TX packets:72147 errors:0 dropped:27791 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:14341062 (13.6 MiB)  TX bytes:10845107 (10.3 MiB)

```
while an enumeration of local interfaces (p.ex. the  code at https://stackoverflow.com/questions/3653065/get-local-ip-address-in-node-js?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa - first answer) results in:

```
eth0 192.168.2.136
bat0 192.168.17.1
bat0:1 169.254.135.21

```




Please merge if you think this is ok.