### PR TITLE
fix: multiple Advertisements without network

### DIFF
--- a/advertisements_without_network.js
+++ b/advertisements_without_network.js
@@ -1,19 +1,20 @@
-//docker run --init -it --network none -v $(pwd):/tmp --rm node bash -c "node /tmp/advertisements_without_network.js"
+// docker run --init -it --network none -v $(pwd):/tmp --rm node bash -c "node /tmp/advertisements_without_network.js"
 
-const dnssd = require('./');
+const dnssd = require('./')
 
-const ad = new dnssd.Advertisement(dnssd.tcp('http'), 4321);
-ad.on('error', (err) => {
-  console.log('err1')
-  console.log(err)
+const interfaces = require('os').networkInterfaces()
+Object.entries(interfaces).forEach(([name, addresses]) => {
+  console.log(name)
+  console.log(addresses)
+  if (addresses.filter(addressRecord => addressRecord.family === 'IPv4').length) {
+    const ad = new dnssd.Advertisement(dnssd.tcp('http'), 9999, {
+      interface: name
+    })
+    ad.on('error', err => {
+      console.log(err)
+    })
+    ad.start()
+  }
 })
-const ad2 = new dnssd.Advertisement(dnssd.tcp('http'), 4321);
-ad2.on('error', (err) => {
-  console.log('err2')
-  console.log(err)
-})
 
-ad.start();
-ad2.start();
-
-setInterval(() => console.log('yay'), 1000)
+// setInterval(() => console.log('yay'), 1000)

--- a/advertisements_without_network.js
+++ b/advertisements_without_network.js
@@ -1,0 +1,19 @@
+//docker run --init -it --network none -v $(pwd):/tmp --rm node bash -c "node /tmp/advertisements_without_network.js"
+
+const dnssd = require('./');
+
+const ad = new dnssd.Advertisement(dnssd.tcp('http'), 4321);
+ad.on('error', (err) => {
+  console.log('err1')
+  console.log(err)
+})
+const ad2 = new dnssd.Advertisement(dnssd.tcp('http'), 4321);
+ad2.on('error', (err) => {
+  console.log('err2')
+  console.log(err)
+})
+
+ad.start();
+ad2.start();
+
+setInterval(() => console.log('yay'), 1000)

--- a/lib/NetworkInterface.js
+++ b/lib/NetworkInterface.js
@@ -434,8 +434,10 @@ NetworkInterface.prototype.stop = function () {
 NetworkInterface.prototype._onError = function (err) {
   debug(this._id + ' had an error: ' + err + '\n' + err.stack);
 
+  if (this._usingMe > 0) {
+    this.emit('error', err);
+  }
   this.stop();
-  this.emit('error', err);
 };
 
 module.exports = NetworkInterface;

--- a/src/NetworkInterface.js
+++ b/src/NetworkInterface.js
@@ -425,11 +425,13 @@ NetworkInterface.prototype.stop = function() {
 };
 
 
-NetworkInterface.prototype._onError = function(err) {
+NetworkInterface.prototype._onError = function (err) {
   debug(`${this._id} had an error: ${err}\n${err.stack}`);
 
+  if (this._usingMe > 0) {
+    this.emit('error', err);
+  }
   this.stop();
-  this.emit('error', err);
 };
 
 


### PR DESCRIPTION
Dnssd fails with 

```
events.js:186
      throw er; // Unhandled 'error' event
      ^

Error: send ENETUNREACH 224.0.0.251:5353
    at SendWrap.afterSend [as oncomplete] (dgram.js:678:11)
Emitted 'error' event on NetworkInterface instance at:
    at NetworkInterface._onError (/tmp/lib/NetworkInterface.js:438:8)
    at SendWrap.callback (/tmp/lib/NetworkInterface.js:393:50)
    at SendWrap.afterSend [as oncomplete] (dgram.js:683:8) {
  errno: 'ENETUNREACH',
  code: 'ENETUNREACH',
  syscall: 'send',
  address: '224.0.0.251',
  port: 5353
}
```

if you create multiple Advertisements on a host with no network available. As far I can tell the reason for this is that the Advertisements share one NetworkInterface, that is shut down when the first Advertisement fails, but there are outstanding that nobody is listening to.

Just adding error handlers to Advertisements do not catch the secondary errors, so somebody using dnssd has no way to guard against this condition.

The PR includes a simple way to demonstrate this with Docker.

I am not familiar enough with dnssd if the fix I included is the way to go. If you have a better way forward please let me know.

My motivation for using dnssd is to be able to work without mdns's native dependencies and possible separate Avahi installation. The original problem that I am solving is that this fails on setups with no internet connection,  eg. no gateway and 224.0.0.251:5353 throws ENETUNREACH - the docker incantation is just an easier way to reproduce the issue.