### PR TITLE
Delete cached reference after stopping interface

### DIFF
--- a/lib/NetworkInterface.js
+++ b/lib/NetworkInterface.js
@@ -428,6 +428,15 @@ NetworkInterface.prototype.stop = function () {
   this._sockets = [];
   this._buffers = [];
 
+  var intf = this;
+
+  // Remove any entries from active interfaces.
+  Object.keys(activeInterfaces).forEach(function (name) {
+    if (activeInterfaces[name] === intf) {
+      delete activeInterfaces[name];
+    }
+  });
+
   debug('Done.');
 };
 

--- a/src/NetworkInterface.js
+++ b/src/NetworkInterface.js
@@ -421,6 +421,15 @@ NetworkInterface.prototype.stop = function() {
   this._sockets = [];
   this._buffers = [];
 
+  const intf = this;
+
+  // Remove any entries from active interfaces.
+  Object.keys(activeInterfaces).forEach((name) => {
+    if (activeInterfaces[name] === intf) {
+      delete activeInterfaces[name];
+    }
+  });
+
   debug('Done.');
 };
 

--- a/test/tests/NetworkInterface.test.js
+++ b/test/tests/NetworkInterface.test.js
@@ -604,6 +604,15 @@ describe('NetworkInterface', function() {
       intf._sockets = [socket];
       intf.stop();
     });
+
+    it.only('should remove interface from active interfaces cache', function() {
+      const intf = new NetworkInterface.get();
+
+      intf.stop();
+      const newIntf = new NetworkInterface.get();
+
+      expect(newIntf).to.not.equal(intf)
+    });
   });
 
 });


### PR DESCRIPTION
Fixes #17 

The issue is that we were still using the IP address from the first
NetworkInterface instance, even though it is not valid for the new
network. Clearing the interface from `activeInterfaces` on stop solves
the problem.

I added a test that works on node 10.5.0 (version of last passing travis run), but the whole suite fails on newer node versions, something to do with the fake socket in tests. The suite fails for me on node 10.9.0 and 10.15.2 (the versions I happen to have installed).